### PR TITLE
Handle Chrome DevTools well-known request

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -67,6 +67,17 @@ form.addEventListener('submit', async (e) => {
 def index():
     return render_template_string(TEMPLATE)
 
+
+@app.route("/.well-known/appspecific/com.chrome.devtools.json", methods=["GET"])
+def chrome_devtools_placeholder():
+    """Serve an empty JSON file to avoid 404s from Chrome DevTools.
+
+    Some browsers request this path automatically to check for DevTools
+    configuration.  Returning an empty JSON response prevents 404 errors
+    cluttering the server logs when the app is accessed via a browser.
+    """
+    return Response("{}", mimetype="application/json")
+
 @app.route("/transcribe", methods=["POST"])
 def transcribe():
     uploaded = request.files.get("file")


### PR DESCRIPTION
## Summary
- avoid 404s for `/.well-known/appspecific/com.chrome.devtools.json` by returning empty JSON

## Testing
- `python -m py_compile web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a396e14420832b9636192707168277